### PR TITLE
add appveyor to check builds on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# From https://www.snoyman.com/blog/2016/08/appveyor-haskell-windows-ci
+build: off
+
+install:
+- git submodule update --init --recursive
+
+before_test:
+# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
+- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+
+- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
+- 7z x stack.zip stack.exe
+
+clone_folder: "c:\\stack"
+environment:
+  global:
+    STACK_ROOT: "c:\\sr"
+
+test_script:
+- stack setup > nul
+# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
+# descriptor
+- echo "" | stack --no-terminal test


### PR DESCRIPTION
Hi,
in another project, we debated whether it makes sense to embed Javascript with your project.
One of the main questions was how readily the C backend would build on Windows.

Since none of us really knew, I quickly tried it out by executing your tests on Appveyor.
The implementation is basically just a version of the reference from
https://www.snoyman.com/blog/2016/08/appveyor-haskell-windows-ci.

You can see the results here: https://ci.appveyor.com/project/MatthiasKauer/hs-duktape
As far as I can tell, it works.

I have not added a badge to the README because it'd make more sense to have it run on Appveyor under your name first.

What do you think?

Best regards,
Matthias