### PR TITLE
Extend JS-HS FFI

### DIFF
--- a/library/Scripting/Duktape/Raw.hs
+++ b/library/Scripting/Duktape/Raw.hs
@@ -20,6 +20,9 @@ foreign import capi "duktape.h value DUK_TYPE_BUFFER"    c_DUK_TYPE_BUFFER ∷ C
 foreign import capi "duktape.h value DUK_TYPE_POINTER"   c_DUK_TYPE_POINTER ∷ CInt
 foreign import capi "duktape.h value DUK_TYPE_LIGHTFUNC" c_DUK_TYPE_LIGHTFUNC ∷ CInt
 
+-- Duktape return vals
+foreign import capi "duktape.h value DUK_RET_TYPE_ERROR" c_DUK_RET_TYPE_ERROR ∷ CInt
+
 data DuktapeHeap
 
 type DuktapeCtx = MVar (ForeignPtr DuktapeHeap)


### PR DESCRIPTION
This PR makes improvements to the `Duktapeable` typeclass and the JS -> HS FFI.

- Extends the `Duktapeable` typeclass to expose Haskell functions of unlimited arguments to Duktape
- Moves the JSON value conversion required of duktape-exposed functions into the `Duktapeable` typeclass. Haskell functions operating on regular haskell values can now be exposed to Duktape, as long as the arguments and return type have `FromJSON/ToJSON` instances defined.
- Improper calling convention from Javascript into Haskell will throw a `TypeError` that can be caught by the executing Javascript.